### PR TITLE
Skip empty documentation deploy commits

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -51,5 +51,9 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add public/docs
+          if git diff --cached --quiet; then
+            echo "No documentation changes to deploy."
+            exit 0
+          fi
           git commit -m "Update documentation"
           git push origin main  # Change this to the appropriate branch if needed


### PR DESCRIPTION
## Summary
- Add a guard in the docs build workflow to stop when `public/docs` has no staged changes.
- Avoids creating empty "Update documentation" commits and unnecessary pushes.
- Keeps the deployment job quiet when documentation output is unchanged.

## Testing
- Not run (workflow-only change).
- Verified the added `git diff --cached --quiet` check exits before `git commit` when no docs changes are staged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation deployment workflow to check for staged changes before committing and pushing updates, preventing unnecessary commits when no documentation modifications are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->