### PR TITLE
[codex] Add macOS DMG installer artifact

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -105,6 +105,9 @@ jobs:
         uv sync --locked --python 3.12 --group dev
         uv run python saenopy/add_source.py
 
+    - name: Install DMG tooling
+      run: brew install create-dmg
+
     - name: Import Apple signing certificate
       shell: bash
       env:
@@ -122,19 +125,62 @@ jobs:
     - name: Build executable with PyInstaller
       shell: bash
       run: |
-        uv run pyinstaller --copy-metadata imageio --clean -y --dist output/saenopy_run --windowed --icon "saenopy/img/Icon.icns" --add-data "saenopy/img:saenopy/img" saenopy/gui/gui_master.py
-        mv output/saenopy_run/gui_master.app output/saenopy_run/saenopy_mac.app
+        uv run pyinstaller \
+          --copy-metadata imageio \
+          --clean -y \
+          --dist output/saenopy_run \
+          --windowed \
+          --name "Saenopy" \
+          --osx-bundle-identifier "org.fabrylab.saenopy" \
+          --icon "saenopy/img/Icon.icns" \
+          --exclude-module PyQt5 \
+          --exclude-module PyQt6 \
+          --exclude-module PySide2 \
+          --exclude-module PySide6.QtWebEngineCore \
+          --exclude-module PySide6.QtWebEngineWidgets \
+          --add-data "saenopy/img:saenopy/img" \
+          saenopy/gui/gui_master.py
+
+    - name: Configure macOS app metadata
+      shell: bash
+      run: |
+        PLIST="output/saenopy_run/Saenopy.app/Contents/Info.plist"
+        /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName Saenopy" "$PLIST"
+        /usr/libexec/PlistBuddy -c "Set :CFBundleName Saenopy" "$PLIST"
+        /usr/libexec/PlistBuddy -c "Delete :CFBundleDocumentTypes" "$PLIST" || true
+        /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes array" "$PLIST"
+        for index in 0 1 2 3; do
+          /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:$index dict" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:$index:CFBundleTypeName string Saenopy Result" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:$index:CFBundleTypeRole string Viewer" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:$index:LSHandlerRank string Owner" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:$index:CFBundleTypeExtensions array" "$PLIST"
+        done
+        /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:0:CFBundleTypeExtensions:0 string saenopy" "$PLIST"
+        /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:1:CFBundleTypeExtensions:0 string saenopy2D" "$PLIST"
+        /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:2:CFBundleTypeExtensions:0 string saenopySpheroid" "$PLIST"
+        /usr/libexec/PlistBuddy -c "Add :CFBundleDocumentTypes:3:CFBundleTypeExtensions:0 string saenopyOrientation" "$PLIST"
 
     - name: Sign macOS app
       shell: bash
       env:
         DEVELOPER_ID_APPLICATION: ${{ secrets.DEVELOPER_ID_APPLICATION }}
       run: |
-        codesign --force --deep --options runtime --timestamp \
+        codesign_with_retries() {
+          for attempt in 1 2 3 4 5; do
+            if codesign "$@"; then
+              return 0
+            fi
+            echo "codesign failed on attempt $attempt; retrying in $((attempt * 20)) seconds"
+            sleep $((attempt * 20))
+          done
+          codesign "$@"
+        }
+        codesign_with_retries --force --deep --options runtime --timestamp \
           --entitlements .github/macos/entitlements.plist \
           --sign "$DEVELOPER_ID_APPLICATION" \
-          output/saenopy_run/saenopy_mac.app
-        codesign --verify --deep --strict --verbose=2 output/saenopy_run/saenopy_mac.app
+          output/saenopy_run/Saenopy.app
+        codesign --verify --deep --strict --verbose=2 output/saenopy_run/Saenopy.app
 
     - name: Notarize macOS app
       shell: bash
@@ -143,16 +189,54 @@ jobs:
         APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
-        ditto -c -k --keepParent output/saenopy_run/saenopy_mac.app output/saenopy_run/saenopy_mac.notary.zip
-        xcrun notarytool submit output/saenopy_run/saenopy_mac.notary.zip \
+        ditto -c -k --keepParent output/saenopy_run/Saenopy.app output/saenopy_run/Saenopy.notary.zip
+        xcrun notarytool submit output/saenopy_run/Saenopy.notary.zip \
           --apple-id "$APPLE_ID" \
           --password "$APPLE_APP_SPECIFIC_PASSWORD" \
           --team-id "$APPLE_TEAM_ID" \
           --wait
-        xcrun stapler staple output/saenopy_run/saenopy_mac.app
-        xcrun stapler validate output/saenopy_run/saenopy_mac.app
-        rm output/saenopy_run/saenopy_mac.notary.zip
-        ditto -c -k --keepParent output/saenopy_run/saenopy_mac.app output/saenopy_run/saenopy_mac.app.zip
+        xcrun stapler staple output/saenopy_run/Saenopy.app
+        xcrun stapler validate output/saenopy_run/Saenopy.app
+        rm output/saenopy_run/Saenopy.notary.zip
+        ditto -c -k --keepParent output/saenopy_run/Saenopy.app output/saenopy_run/Saenopy.app.zip
+
+    - name: Build and notarize macOS DMG
+      shell: bash
+      env:
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        DEVELOPER_ID_APPLICATION: ${{ secrets.DEVELOPER_ID_APPLICATION }}
+      run: |
+        create-dmg \
+          --volname "Saenopy" \
+          --window-pos 200 120 \
+          --window-size 600 400 \
+          --icon-size 100 \
+          --icon "Saenopy.app" 175 190 \
+          --app-drop-link 425 190 \
+          "output/saenopy_run/Saenopy-mac.dmg" \
+          "output/saenopy_run/Saenopy.app"
+        codesign_with_retries() {
+          for attempt in 1 2 3 4 5; do
+            if codesign "$@"; then
+              return 0
+            fi
+            echo "codesign failed on attempt $attempt; retrying in $((attempt * 20)) seconds"
+            sleep $((attempt * 20))
+          done
+          codesign "$@"
+        }
+        codesign_with_retries --force --timestamp \
+          --sign "$DEVELOPER_ID_APPLICATION" \
+          output/saenopy_run/Saenopy-mac.dmg
+        xcrun notarytool submit output/saenopy_run/Saenopy-mac.dmg \
+          --apple-id "$APPLE_ID" \
+          --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+          --team-id "$APPLE_TEAM_ID" \
+          --wait
+        xcrun stapler staple output/saenopy_run/Saenopy-mac.dmg
+        xcrun stapler validate output/saenopy_run/Saenopy-mac.dmg
 
     - uses: actions/upload-artifact@v6
       with:
@@ -160,7 +244,7 @@ jobs:
         path: output/saenopy_run
 
     - name: Upload GitHub release assets
-      run: gh release upload $TAG output/saenopy_run/saenopy_mac.app.zip --clobber
+      run: gh release upload $TAG output/saenopy_run/Saenopy.app.zip output/saenopy_run/Saenopy-mac.dmg --clobber
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: v1.0.8

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -128,7 +128,7 @@ jobs:
         uv run pyinstaller \
           --copy-metadata imageio \
           --clean -y \
-          --dist output/saenopy_run \
+          --distpath output/saenopy_run \
           --windowed \
           --name "Saenopy" \
           --osx-bundle-identifier "org.fabrylab.saenopy" \

--- a/saenopy/gui/code/gui_code.py
+++ b/saenopy/gui/code/gui_code.py
@@ -1,4 +1,3 @@
-import sys
 import os
 from qtpy import QtCore, QtWidgets, QtGui
 import qtawesome as qta
@@ -93,10 +92,6 @@ class MainWindowCode(QtWidgets.QWidget):
         self.process_finished.connect(self.script_status_changed)
 
         self.select_tab(-1)
-
-        for arg in sys.argv[1:]:
-            if arg.endswith(".py"):
-                self.do_load(arg)
 
     def update_console(self, open_script):
         if len(self.open_scripts) and open_script == self.open_scripts[self.open_scripts_index]:

--- a/saenopy/gui/gui_master.py
+++ b/saenopy/gui/gui_master.py
@@ -36,6 +36,20 @@ def is_result_file(filename):
     return filename.endswith(RESULT_EXTENSIONS)
 
 
+def is_existing_file(filename):
+    try:
+        return os.path.isfile(os.fspath(filename))
+    except TypeError:
+        return False
+
+
+def is_openable_file(filename):
+    if not is_existing_file(filename):
+        return False
+    filename = os.fspath(filename)
+    return filename.endswith(".json") or filename.endswith(".py") or is_result_file(filename)
+
+
 profile_startup("launch module imported")
 
 
@@ -152,7 +166,8 @@ class MainWindow(QtWidgets.QWidget):
         self.first_tab_change = False
 
         for file in sys.argv[1:]:
-            self.open_file(file)
+            if is_openable_file(file):
+                self.open_file(file)
 
     first_tab_change = True
     solver = None
@@ -205,17 +220,18 @@ class MainWindow(QtWidgets.QWidget):
             self.orientation.plotting_window.load(file)
 
     def open_file(self, file):
-        print(file)
-        if file.startswith("--"):
+        if not is_openable_file(file):
             return
+        file = os.fspath(file)
         if file.endswith(".json"):
             try:
                 self._open_analysis_session(file)
                 return
-            except (IndexError, KeyError):
+            except (IndexError, KeyError, json.JSONDecodeError):
                 return
         if file.endswith(".py"):
             self.setTab(6)
+            self.coder.do_load(file)
         elif is_result_file(file) and file.endswith(".saenopy"):
             self.setTab(2)
             self.solver.tabs.setCurrentIndex(1)
@@ -232,8 +248,6 @@ class MainWindow(QtWidgets.QWidget):
             self.setTab(4)
             self.orientation.tabs.setCurrentIndex(1)
             self.orientation.plotting_window.add_files([file])
-        else:
-            raise ValueError("Unknown file type")
 
 
 def main():  # pragma: no cover

--- a/saenopy/gui/gui_master.py
+++ b/saenopy/gui/gui_master.py
@@ -1,5 +1,7 @@
 import json
+import os
 import sys
+import time
 import traceback
 
 from qtpy import QtCore, QtWidgets, QtGui
@@ -17,6 +19,42 @@ from saenopy.gui.code.gui_code import MainWindowCode
 from saenopy.gui.material_fit.gui_fit import MainWindowFit
 from saenopy.gui.tfm2d.gui_2d import MainWindow2D
 from saenopy.gui.common.resources import resource_path, resource_icon
+
+
+PROFILE_STARTUP = os.environ.get("SAENOPY_PROFILE_STARTUP") == "1"
+PROFILE_EXIT_AFTER_SHOW = os.environ.get("SAENOPY_PROFILE_EXIT_AFTER_SHOW") == "1"
+START_TIME = time.perf_counter()
+RESULT_EXTENSIONS = (".saenopy", ".saenopy2D", ".saenopySpheroid", ".saenopyOrientation")
+
+
+def profile_startup(label):
+    if PROFILE_STARTUP:
+        print(f"[SAENOPY-STARTUP] {time.perf_counter() - START_TIME:.3f}s {label}", flush=True)
+
+
+def is_result_file(filename):
+    return filename.endswith(RESULT_EXTENSIONS)
+
+
+profile_startup("launch module imported")
+
+
+class SaenopyApplication(QtWidgets.QApplication):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.open_files = []
+        self.main_window = None
+
+    def event(self, event):
+        if event.type() == QtCore.QEvent.FileOpen:
+            path = event.file()
+            if path:
+                if self.main_window is None:
+                    self.open_files.append(path)
+                else:
+                    QtCore.QTimer.singleShot(0, lambda path=path: self.main_window.open_file(path))
+                return True
+        return super().event(event)
 
 
 class InfoBox(QtWidgets.QWidget):
@@ -114,43 +152,7 @@ class MainWindow(QtWidgets.QWidget):
         self.first_tab_change = False
 
         for file in sys.argv[1:]:
-            print(file)
-            if file.endswith(".json"):
-                try:
-                    with open(file, "r") as fp:
-                        data = json.load(fp)
-                    filename = data[0]["paths"][0]["path"]
-                    if filename.endswith(".saenopy"):
-                        self.setTab(2)
-                        self.solver.tabs.setCurrentIndex(1)
-                        self.solver.plotting_window.load(file)
-                    elif filename.endswith("saenopy2D"):
-                        self.setTab(5)
-                        self.pytfm2d.tabs.setCurrentIndex(1)
-                        self.pytfm2d.plotting_window.load(file)
-                    elif filename.endswith(".saenopySpheroid"):
-                        self.setTab(3)
-                        self.spheroid.tabs.setCurrentIndex(1)
-                        self.spheroid.plotting_window.load(file)
-                    elif filename.endswith(".saenopyOrientation"):
-                        self.setTab(4)
-                        self.orientation.tabs.setCurrentIndex(1)
-                        self.orientation.plotting_window.load(file)
-                    continue
-                except (IndexError, KeyError):
-                    continue
-            if file.endswith(".py"):
-                self.setTab(6)
-            elif file.endswith(".saenopy"):
-                self.setTab(2)
-            elif file.endswith(".saenopy2D"):
-                self.setTab(5)
-            elif file.endswith(".saenopySpheroid"):
-                self.setTab(3)
-            elif file.endswith(".saenopyOrientation"):
-                self.setTab(4)
-            else:
-                raise ValueError("Unknown file type")
+            self.open_file(file)
 
     first_tab_change = True
     solver = None
@@ -181,24 +183,88 @@ class MainWindow(QtWidgets.QWidget):
     def setTab(self, value):
         self.tabs.setCurrentIndex(value)
 
+    def _open_analysis_session(self, file):
+        with open(file, "r") as fp:
+            data = json.load(fp)
+        filename = data[0]["paths"][0]["path"]
+        if filename.endswith(".saenopy"):
+            self.setTab(2)
+            self.solver.tabs.setCurrentIndex(1)
+            self.solver.plotting_window.load(file)
+        elif filename.endswith(".saenopy2D"):
+            self.setTab(5)
+            self.pytfm2d.tabs.setCurrentIndex(1)
+            self.pytfm2d.plotting_window.load(file)
+        elif filename.endswith(".saenopySpheroid"):
+            self.setTab(3)
+            self.spheroid.tabs.setCurrentIndex(1)
+            self.spheroid.plotting_window.load(file)
+        elif filename.endswith(".saenopyOrientation"):
+            self.setTab(4)
+            self.orientation.tabs.setCurrentIndex(1)
+            self.orientation.plotting_window.load(file)
+
+    def open_file(self, file):
+        print(file)
+        if file.startswith("--"):
+            return
+        if file.endswith(".json"):
+            try:
+                self._open_analysis_session(file)
+                return
+            except (IndexError, KeyError):
+                return
+        if file.endswith(".py"):
+            self.setTab(6)
+        elif is_result_file(file) and file.endswith(".saenopy"):
+            self.setTab(2)
+            self.solver.tabs.setCurrentIndex(1)
+            self.solver.plotting_window.add_files([file])
+        elif is_result_file(file) and file.endswith(".saenopy2D"):
+            self.setTab(5)
+            self.pytfm2d.tabs.setCurrentIndex(1)
+            self.pytfm2d.plotting_window.add_files([file])
+        elif is_result_file(file) and file.endswith(".saenopySpheroid"):
+            self.setTab(3)
+            self.spheroid.tabs.setCurrentIndex(1)
+            self.spheroid.plotting_window.add_files([file])
+        elif is_result_file(file) and file.endswith(".saenopyOrientation"):
+            self.setTab(4)
+            self.orientation.tabs.setCurrentIndex(1)
+            self.orientation.plotting_window.add_files([file])
+        else:
+            raise ValueError("Unknown file type")
+
 
 def main():  # pragma: no cover
-    app = QtWidgets.QApplication(sys.argv)
+    profile_startup("main entered")
+    app = SaenopyApplication(sys.argv)
+    profile_startup("QApplication created")
     if sys.platform.startswith('win'):
         import ctypes
         myappid = 'fabrylab.saenopy.master'  # arbitrary string
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
 
+    profile_startup("main window construction started")
     window = MainWindow()
+    app.main_window = window
+    for file in app.open_files:
+        QtCore.QTimer.singleShot(0, lambda file=file: window.open_file(file))
+    app.open_files.clear()
+    profile_startup("main window constructed")
     window.show()
-    try:
-        import pyi_splash
-        # Close the splash screen. It does not matter when the call
-        # to this function is made, the splash screen remains open until
-        # this function is called or the Python program is terminated.
-        pyi_splash.close()
-    except (ImportError, RuntimeError):
-        pass
+    profile_startup("main window shown")
+    if os.environ.get("_PYI_SPLASH_IPC"):
+        try:
+            import pyi_splash
+            # Close the splash screen. It does not matter when the call
+            # to this function is made, the splash screen remains open until
+            # this function is called or the Python program is terminated.
+            pyi_splash.close()
+        except (ImportError, RuntimeError):
+            pass
+    if PROFILE_EXIT_AFTER_SHOW:
+        QtCore.QTimer.singleShot(0, app.quit)
 
     from traceback import format_exception
     def except_hook(type_, value, tb):


### PR DESCRIPTION
## Summary

- cherry-picks `2671f6c` to add a macOS DMG build path to the installer workflow
- renames the generated macOS app bundle to `Saenopy.app` and uploads both `Saenopy.app.zip` and `Saenopy-mac.dmg`
- adds macOS app metadata/document type handling from the original commit

## Validation

- `git cherry-pick 2671f6c` completed cleanly on `origin/master`
- `git diff --check HEAD~1..HEAD` passed
- workflow runtime validation is left to GitHub Actions because the macOS signing/notarization path requires CI secrets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macOS release packaging with a signed, notarized app and DMG for easier installation.

* **Bug Fixes**
  * Made opening files from the desktop/file manager more reliable, including queued open requests on app launch.
  * Improved handling of supported result and analysis files when launching the app or opening files directly.
  * Increased reliability of macOS signing and notarization steps to reduce release issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->