### PR TITLE
[codex] Tolerate Coveralls upload outages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,15 @@ jobs:
       - run: |
           uv run coverage run -m pytest --durations=10 --durations-min=1 -o faulthandler_timeout=120
         timeout-minutes: 10
-      - run: uv run coveralls
+      - name: Upload coverage to Coveralls
+        run: |
+          for attempt in 1 2 3; do
+            if uv run coveralls; then
+              exit 0
+            fi
+            echo "Coveralls upload failed on attempt $attempt; retrying in $((attempt * 30)) seconds"
+            sleep $((attempt * 30))
+          done
+          echo "::warning::Coveralls upload failed after 3 attempts; continuing because tests passed."
         env:
           GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
## Summary

- retries the Coveralls upload up to 3 times when the external service fails
- emits a GitHub Actions warning instead of failing the test job after repeated Coveralls upload failures
- keeps the actual `coverage run -m pytest` step as the CI gate

## Why

The current CI can fail even after tests pass when Coveralls returns a transient server-side error such as `502 Bad Gateway`. Coverage publishing is useful, but an external upload outage should not block unrelated PRs.

## Validation

- `git diff --check` passed
- reviewed the workflow diff; runtime validation will happen in GitHub Actions
