### PR TITLE
Fix swapped lambda_s and d_s in the default material fallback

### DIFF
--- a/saenopy/gui/solver/modules/TabResultView.py
+++ b/saenopy/gui/solver/modules/TabResultView.py
@@ -94,7 +94,9 @@ class TabResultView(TabModule):
         # self.M.setMaterialModel(SemiAffineFiberMaterial(1645, 0.0008, 0.0075, 0.033), generate_lookup=False)
         if self.M.material_model is None:
             print("Warning using default material parameters")
-            self.M.set_material_model(SemiAffineFiberMaterial(1449, 0.00215, 0.055, 0.032), generate_lookup=False)
+            self.M.set_material_model(
+                SemiAffineFiberMaterial(k=1449, d_0=0.00215, lambda_s=0.032, d_s=0.055),
+                generate_lookup=False)
         self.M._check_relax_ready()
         self.M._prepare_temporary_quantities()
         self.point_cloud2["stiffness"] = self.M.get_max_tet_stiffness() / 6


### PR DESCRIPTION
`SemiAffineFiberMaterial` takes `(k, d_0, lambda_s, d_s)`, but the default
fallback in `TabResultView.calculateStiffness` passed its last two values
positionally in the other order:

```python
SemiAffineFiberMaterial(1449, 0.00215, 0.055, 0.032)   # lambda_s=0.055, d_s=0.032
```

Every other place in the repository that names these values has them the other
way round — `lambda_s=0.032, d_s=0.055`:

- `saenopy/examples.py` (the bundled dynamical single cell dataset)
- `docs/source/3d_tfm/examples/2_DynamicalSingleCellTFM.py`
- `saenopy/gui/spheroid/modules/LookupTable.py`, which describes them as the
  collagen I 1.2 mg/ml reference

The three other live call sites of `SemiAffineFiberMaterial`
(`Regularizer.py` twice, `code_evluate_normal.py`) all pass their parameters in
the correct order, so this is the only one affected.

## How it probably happened

The lookup table dialog lists the parameters as "**k**, **d_0**, **ds** and
**lambda_s**" and then quotes them in that same order:

> Default values are taken from a collagen I hydrogel (1.2mg/ml) with k=1449,
> d_0=0.00215, ds=0.055, lambda_s=0.032.

Typing that order into a positional call produces exactly this swap. The line
has been unchanged since it was introduced; only the method rename touched it
since.

## Impact

Limited to the stiffness display when no material model has been set — the
branch that prints `Warning using default material parameters`. But the effect
is not small. The two orderings agree below the stiffening onset and then
diverge sharply:

| strain | as shipped | corrected | difference |
| ---: | ---: | ---: | ---: |
| 0.032 | 1449 | 1449 | 0% |
| 0.055 | 1449 | 2201 | −34% |
| 0.10 | 5913 | 4989 | +19% |
| 0.30 | 3062919 | 189351 | +1518% |

## The fix

Pass the parameters by keyword, so the order cannot silently matter again.

`test/test_material.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
